### PR TITLE
Fix origin keys live url

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -38,10 +38,8 @@ module AdyenAPI
         "http://localhost:#{@mock_port}"
       else
         case service
-        when "Checkout"
+        when "Checkout", "CheckoutUtility"
           url = "https://checkout-#{@env}.adyen.com/checkout"
-        when "CheckoutUtility"
-          url = "https://checkout-#{@env}.adyen.com"
         when "Account", "Fund", "Notification"
           url = "https://cal-#{@env}.adyen.com/cal/services"
         when "Recurring", "Payment", "Payout"

--- a/lib/adyen/version.rb
+++ b/lib/adyen/version.rb
@@ -1,4 +1,4 @@
 module AdyenAPI
   NAME = "adyen-ruby-api-library"
-  VERSION = "2.0.0".freeze
+  VERSION = "2.0.1".freeze
 end

--- a/spec/checkout_utility_spec.rb
+++ b/spec/checkout_utility_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe AdyenAPI::CheckoutUtility, service: "checkout utility" do
 
   it "sets the correct service URL base" do
     client = AdyenAPI::Client.new(env: :test)
-    expect(client.service_url_base(@shared_values[:service])).to eq("https://checkout-test.adyen.com")
+    expect(client.service_url_base(@shared_values[:service])).to eq("https://checkout-test.adyen.com/checkout")
   end
 
   # must be created manually because every field in the response is an array


### PR DESCRIPTION
Live URL was broken. Adyen support wasn't able to give an answer on the correct url. I checked one of their SDKs - [sdk for php ](https://github.com/Adyen/adyen-magento/blob/c951ea93296f37f17e1965fd652da23124f88e66/app/code/community/Adyen/Payment/Model/Api.php#L759) - and got the right URL format. 


