### PR TITLE
fix CheckoutUtility URL to /checkout/

### DIFF
--- a/lib/adyen/client.rb
+++ b/lib/adyen/client.rb
@@ -59,7 +59,7 @@ module AdyenAPI
 
     # construct full URL from service and endpoint
     def service_url(service, action, version)
-      if service == "Checkout"
+      if service == "Checkout" || service == "CheckoutUtility"
         "#{service_url_base(service)}/v#{version}/#{action}"
       else
         "#{service_url_base(service)}/#{service}/v#{version}/#{action}"

--- a/lib/adyen/services/checkout_utility.rb
+++ b/lib/adyen/services/checkout_utility.rb
@@ -5,7 +5,7 @@ module AdyenAPI
     DEFAULT_VERSION = 1
 
     def initialize(client, version = DEFAULT_VERSION)
-      service = 'CheckoutUtility'
+      service = 'Checkout'
       method_names = [
         :origin_keys
       ]


### PR DESCRIPTION
* Old checkout utility url is broken 
* Ports a fix from the original gem was introduced in https://github.com/Adyen/adyen-ruby-api-library/pull/36

For testing: 
  * Point the gem locally to the develop branch `gem 'adyen-ruby-api-library',     github: 'onrunning/adyen-ruby-api-library', branch: 'develop', ref: '95a3f45'` 
 * You should be able to go through the checkout without issues 